### PR TITLE
Make non-const `find` use const version

### DIFF
--- a/include/skip_list.h
+++ b/include/skip_list.h
@@ -32,7 +32,7 @@ public:
     public:
         using value_type = it_value_type;
         using node_type = std::conditional_t<std::is_const_v<value_type>,
-            const Skip_node, Skip_node>;
+                                             const Skip_node, Skip_node>;
 
         iterator_base() : curr{nullptr} {};
 


### PR DESCRIPTION
This helps to avoid code duplication while implementing the same methods for const and non-const versions, 
although it breaks `TEST(Skip_list, top_level)`, line 459 in `skip_list_test.cpp` for reasons unknown to me.